### PR TITLE
Fixed unnecessary mDNS re-advertisement when discovered peer already exists in PeerMap

### DIFF
--- a/src/peer/manager.rs
+++ b/src/peer/manager.rs
@@ -1,0 +1,30 @@
+use crate::peer::PeerMap;
+use std::net::SocketAddr;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// Attempts to add a new peer to the peer map.
+/// Returns `true` if the peer was newly added, `false` if it already existed.
+pub async fn handle_new_peer(
+    peer_id: String,
+    addr: SocketAddr,
+    peers: PeerMap,
+    advertise_tx: &UnboundedSender<()>,
+) -> anyhow::Result<bool> {
+    let mut peers_map = peers.write().await;
+
+    if peers_map.contains_key(&peer_id) {
+        log::debug!("Peer {peer_id} already exists, skipping update.");
+        return Ok(false);
+    }
+
+    log::debug!("Adding new peer {peer_id} at {addr} to peer map.");
+    peers_map.insert(peer_id.clone(), addr);
+
+    // Drop lock before sending
+    drop(peers_map);
+
+    // Notify the main loop
+    advertise_tx.send(()).ok();
+
+    Ok(true)
+}

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -1,3 +1,5 @@
+pub mod manager;
 pub mod map;
 
+pub use manager::*;
 pub use map::PeerMap;


### PR DESCRIPTION
- Moved new peer insertion and advertisement logic into `handle_new_peer` helper for better modularity and testability.
- Removed redundant peer deduplication using `HashSet` in favor of peer map lookup.
- Downgraded peer discovery logs to `debug` level.
- Fixed `extract_peer_info` to return `peer_id` instead of `peer_name`.
- Fixed #3 