### PR TITLE
Refactored Peer Management with Structured PeerInfo and Metadata

### DIFF
--- a/research/match-guard.md
+++ b/research/match-guard.md
@@ -1,0 +1,47 @@
+### 📌 Syntax Breakdown:
+
+```rust
+Some(existing_peer_info)
+    if !peer_info
+        .metadata
+        .is_different(&existing_peer_info.metadata) =>
+```
+
+Let’s break this down:
+
+#### ✅ `Some(existing_peer_info)`
+
+This is a **pattern** that matches if the result of `peers_map.get(&peer_info.id)` is a `Some(...)` variant. The `existing_peer_info` is a reference to the value inside the `Some`.
+
+#### ✅ `if !peer_info.metadata.is_different(&existing_peer_info.metadata)`
+
+This is the **match guard** — an additional condition that must also be true for this arm to match.
+
+Together, this arm is only taken when:
+
+- There **is** an existing peer (`Some(existing_peer_info)`), **and**
+- The **metadata is not different**, meaning no meaningful update is needed.
+
+### 🧠 General Match Guard Syntax:
+
+```rust
+match value {
+    PATTERN if CONDITION => { ... },
+    _ => { ... },
+}
+```
+
+The `if` after a match arm is the guard — it's evaluated only if the pattern matches. If it evaluates to `false`, Rust will move on to try the next pattern.
+
+### 👀 Example in Isolation:
+
+```rust
+match Some(42) {
+    Some(x) if x > 50 => println!("Greater than 50: {}", x),
+    Some(x) => println!("Got something: {}", x),
+    None => println!("Got nothing"),
+}
+```
+
+This will print: `Got something: 42`
+Because although `Some(x)` matches, the guard `x > 50` fails — so it tries the next arm.

--- a/src/peer/conversion.rs
+++ b/src/peer/conversion.rs
@@ -1,0 +1,34 @@
+use super::{PeerInfo, PeerMetadata};
+
+// This enables us to convert a PeerInfo struct into a tuple of (String, PeerMetadata).
+//
+// example:
+// let info = PeerInfo {
+//     id: "abc123".into(),
+//     metadata: PeerMetadata { /* ... */ },
+// };
+// let (id, metadata): (String, PeerMetadata) = info.into();
+//
+// This is helpful when we want to store or serialize peers as key-value pairs (e.g., in a HashMap<String, PeerMetadata>).
+impl From<PeerInfo> for (String, PeerMetadata) {
+    fn from(info: PeerInfo) -> Self {
+        (info.id, info.metadata)
+    }
+}
+
+// This allows us to create a PeerInfo from a borrowed ID (&str) and metadata reference (&PeerMetadata).
+//
+// example:
+// let id = "abc123";
+// let meta = PeerMetadata { /* ... */ };
+// let info: PeerInfo = (id, &meta).into();
+//
+// This is useful when reading from a map (HashMap<String, PeerMetadata>) and we want to recreate a PeerInfo from its entry without moving values.
+impl From<(&str, &PeerMetadata)> for PeerInfo {
+    fn from((id, meta): (&str, &PeerMetadata)) -> Self {
+        PeerInfo {
+            id: id.to_string(),
+            metadata: meta.clone(),
+        }
+    }
+}

--- a/src/peer/info.rs
+++ b/src/peer/info.rs
@@ -1,0 +1,20 @@
+use super::PeerMetadata;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerInfo {
+    pub id: String,
+    pub metadata: PeerMetadata,
+}
+
+impl PeerInfo {
+    pub fn new(id: impl Into<String>, metadata: PeerMetadata) -> Self {
+        Self {
+            id: id.into(),
+            metadata,
+        }
+    }
+
+    pub fn log(&self) {
+        log::debug!("\n{self:#?}");
+    }
+}

--- a/src/peer/manager.rs
+++ b/src/peer/manager.rs
@@ -1,26 +1,39 @@
-use crate::peer::PeerMap;
-use std::net::SocketAddr;
+use crate::peer::{PeerInfo, PeerMap};
 use tokio::sync::mpsc::UnboundedSender;
 
-/// Attempts to add a new peer to the peer map.
-/// Returns `true` if the peer was newly added, `false` if it already existed.
+/// Attempts to add or update a peer in the peer map.
+/// Returns `true` if the peer was newly added or updated meaningfully, `false` otherwise.
 pub async fn handle_new_peer(
-    peer_id: String,
-    addr: SocketAddr,
+    peer_info: PeerInfo,
     peers: PeerMap,
     advertise_tx: &UnboundedSender<()>,
 ) -> anyhow::Result<bool> {
     let mut peers_map = peers.write().await;
 
-    if peers_map.contains_key(&peer_id) {
-        log::debug!("Peer {peer_id} already exists, skipping update.");
-        return Ok(false);
+    // Looks up the current peer in the peers_map by its id.
+    // Returns Some(existing_peer_info) if found, or None if it's a new peer.
+    match peers_map.get(&peer_info.id) {
+        // If the peer already exists and the metadata is not different
+        // 1. Log that there's nothing to update.
+        // 2. Return false to indicate no update was performed.
+        Some(existing_peer_info)
+            if !peer_info
+                .metadata
+                .is_different(&existing_peer_info.metadata) =>
+        {
+            log::debug!("Nothing to update for peer {}", peer_info.id);
+            return Ok(false);
+        }
+        // If the peer already exists but the metadata is different or the peer is new
+        // It logs the new or updated peer using PeerInfo::log() for structured debug output.
+        // Then inserts the peer info into the map.
+        _ => {
+            peer_info.log();
+            peers_map.insert(peer_info.id.clone(), peer_info.clone());
+        }
     }
 
-    log::debug!("Adding new peer {peer_id} at {addr} to peer map.");
-    peers_map.insert(peer_id.clone(), addr);
-
-    // Drop lock before sending
+    // Drop the lock before notifying
     drop(peers_map);
 
     // Notify the main loop

--- a/src/peer/map.rs
+++ b/src/peer/map.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
-use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub type PeerMap = Arc<RwLock<HashMap<String, SocketAddr>>>;
+// Use when you're inside the same module hierarchy, like in a sibling module.
+// super means "go up one level in the module tree."
+use super::PeerInfo;
+
+pub type PeerMap = Arc<RwLock<HashMap<String, PeerInfo>>>;

--- a/src/peer/metadata.rs
+++ b/src/peer/metadata.rs
@@ -1,0 +1,24 @@
+use std::net::SocketAddr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerMetadata {
+    pub addr: SocketAddr,
+    pub name: String,
+    pub instance: String,
+    pub version: String,
+    pub platform: String,
+}
+
+impl PeerMetadata {
+    pub fn is_different(&self, other: &Self) -> bool {
+        self.addr != other.addr
+            || self.name != other.name
+            || self.instance != other.instance
+            || self.version != other.version
+            || self.platform != other.platform
+    }
+
+    pub fn log(&self) {
+        log::debug!("\n{self:#?}");
+    }
+}

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -1,5 +1,10 @@
+pub mod conversion;
+pub mod info;
 pub mod manager;
 pub mod map;
+pub mod metadata;
 
+pub use info::PeerInfo;
 pub use manager::*;
 pub use map::PeerMap;
+pub use metadata::PeerMetadata;


### PR DESCRIPTION
### Overview

This PR refactors the peer management system by introducing two new structs: `PeerInfo` and `PeerMetadata`. These replace the previous `(String, SocketAddr)` tuple representation and allow for richer peer data handling, logging, and future extensibility.

### Key Changes

- Introduced `PeerInfo` (peer ID + metadata) and `PeerMetadata` (address, name, instance, platform, version)
- Replaced `HashMap<String, SocketAddr>` with `HashMap<String, PeerInfo>` in `PeerMap`
- Updated `handle_new_peer` to compare metadata using a `.is_different()` check before updating peers
- Added `conversion.rs` with `From` trait implementations for ergonomic mapping between tuple and struct forms
- Refactored `discovery.rs` to extract full peer info from mDNS responses (TXT records)
- Improved logging by using `PeerInfo::log()` for consistent debug output

### Benefits

- Enables tracking more detailed peer metadata (platform, version, etc.)
- Prevents unnecessary updates by detecting real differences in peer info
- Simplifies future enhancements like peer filtering, custom sorting, or richer UI displays
- Adds testability and code clarity by using named types